### PR TITLE
ホームページのCMSイベント情報同期を修正

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -14,9 +14,11 @@ import { client, Event, HeroImage } from "./lib/microcms";
 import { Metadata } from "next";
 
 // サーバーコンポーネントに変更（'use client'を削除）
+export const revalidate = 3600; // 1時間（秒単位）
+
 export default async function Home() {
   // MicroCMSから次回のイベントを取得
-  const response = await client.get({
+  const response = await client.getList({
     endpoint: "events",
     queries: { filters: "category[contains]upcoming", limit: 1 },
   });


### PR DESCRIPTION
- client.get() から client.getList() に変更してイベントページと統一
- revalidate設定を追加（1時間ごとに更新）
- CMSでイベント情報を更新した際にホームページでも正しく反映されるように修正

🤖 Generated with [Claude Code](https://claude.com/claude-code)