### PR TITLE
イベントページのキャッシュ更新間隔を1時間に短縮

### DIFF
--- a/app/event/page.tsx
+++ b/app/event/page.tsx
@@ -14,7 +14,7 @@ import Header from "../components/Header";
 import { client } from "../lib/microcms";
 import type { Event } from "../lib/microcms";
 // サーバーコンポーネントに変更
-export const revalidate = 86400; // 24時間（秒単位）
+export const revalidate = 3600; // 1時間（秒単位）
 export default async function EventPage() {
   // MicroCMSからデータを取得
   const response = await client.getList({


### PR DESCRIPTION
revalidateを86400秒(24時間)から3600秒(1時間)に変更し、ホームページと同期。 これによりmicroCMSでの更新が最大1時間以内にイベントページに反映されるようになります。

🤖 Generated with [Claude Code](https://claude.com/claude-code)