### PR TITLE
feat: microCMS Webhook で On-Demand ISR を実装（即時反映）

### DIFF
--- a/app/api/revalidate/route.ts
+++ b/app/api/revalidate/route.ts
@@ -1,0 +1,92 @@
+// microCMS Webhook からの通知を受けて On-Demand ISR を発火させる。
+// microCMS 管理画面 > サービス設定 > API > Webhook で
+// 「Vercel」または「カスタム通知」として下記 URL を登録し、
+// シークレットを MICROCMS_WEBHOOK_SECRET と一致させる。
+//   URL: https://<your-domain>/api/revalidate
+//
+// 署名検証は HMAC-SHA256 で行う。ヘッダ名は `X-MICROCMS-Signature`。
+// 参考: https://document.microcms.io/manual/webhook-setting
+import { NextResponse } from 'next/server';
+import { revalidatePath } from 'next/cache';
+import crypto from 'node:crypto';
+
+export const runtime = 'nodejs';
+
+// Webhook で更新通知が来た endpoint と、対応する再生成パスの対応表。
+// 新しい endpoint を増やしたらここに足すだけで反映される。
+const ENDPOINT_TO_PATHS: Record<string, string[]> = {
+  events: ['/', '/event'],
+  hero: ['/'],
+};
+
+function timingSafeEqualHex(a: string, b: string): boolean {
+  // タイミング攻撃を避けるため固定時間で比較する。
+  if (a.length !== b.length) return false;
+  const bufA = Buffer.from(a, 'hex');
+  const bufB = Buffer.from(b, 'hex');
+  if (bufA.length !== bufB.length) return false;
+  return crypto.timingSafeEqual(bufA, bufB);
+}
+
+export async function POST(req: Request) {
+  const secret = process.env.MICROCMS_WEBHOOK_SECRET?.trim();
+  if (!secret) {
+    // 設定漏れは早期に潰す。
+    return NextResponse.json(
+      { error: 'MICROCMS_WEBHOOK_SECRET is not set' },
+      { status: 500 },
+    );
+  }
+
+  const signature = req.headers.get('x-microcms-signature');
+  if (!signature) {
+    return NextResponse.json({ error: 'missing signature' }, { status: 401 });
+  }
+
+  // 署名検証より前に body サイズで早期遮断する。
+  // 偽署名 + 巨大 body で HMAC 計算リソースを食わせる DoS を防ぐ目的。
+  // microCMS の Webhook payload は通常数 KB 程度なので 64KB で十分。
+  const MAX_BODY_BYTES = 64 * 1024;
+  const contentLength = Number(req.headers.get('content-length') ?? '0');
+  if (contentLength > MAX_BODY_BYTES) {
+    return NextResponse.json({ error: 'payload too large' }, { status: 413 });
+  }
+
+  // 署名は body の生バイト列に対する HMAC なので text() で受ける。
+  const rawBody = await req.text();
+  // Content-Length ヘッダが欠落 / 偽装されているケースに備えて再チェック。
+  if (Buffer.byteLength(rawBody, 'utf8') > MAX_BODY_BYTES) {
+    return NextResponse.json({ error: 'payload too large' }, { status: 413 });
+  }
+  const expected = crypto.createHmac('sha256', secret).update(rawBody).digest('hex');
+
+  if (!timingSafeEqualHex(signature, expected)) {
+    return NextResponse.json({ error: 'invalid signature' }, { status: 401 });
+  }
+
+  let payload: { api?: string; type?: string; id?: string } = {};
+  try {
+    payload = JSON.parse(rawBody);
+  } catch {
+    return NextResponse.json({ error: 'invalid json' }, { status: 400 });
+  }
+
+  const endpoint = payload.api;
+  const paths = endpoint ? ENDPOINT_TO_PATHS[endpoint] : undefined;
+
+  if (!paths) {
+    // 未登録 endpoint からの通知は 200 で返しつつ何もしない (Webhook を切らないため)。
+    return NextResponse.json({ revalidated: false, reason: 'unknown endpoint', endpoint });
+  }
+
+  for (const path of paths) {
+    revalidatePath(path);
+  }
+
+  return NextResponse.json({
+    revalidated: true,
+    endpoint,
+    paths,
+    now: Date.now(),
+  });
+}

--- a/app/event/page.tsx
+++ b/app/event/page.tsx
@@ -14,7 +14,9 @@ import Header from "../components/Header";
 import { client } from "../lib/microcms";
 import type { Event } from "../lib/microcms";
 // サーバーコンポーネントに変更
-export const revalidate = 3600; // 1時間（秒単位）
+// On-Demand ISR (microCMS Webhook → /api/revalidate) で即時反映する。
+// 下記の数値は Webhook が万一失敗した場合のフォールバックの最大鮮度。
+export const revalidate = 86400; // 24時間（秒単位）。通常は webhook 経由で即時更新される
 export default async function EventPage() {
   // MicroCMSからデータを取得
   const response = await client.getList({

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -13,7 +13,9 @@ import { Metadata } from "next";
 import RelativeLink from "./components/RelativeLink";
 
 // サーバーコンポーネントに変更（'use client'を削除）
-export const revalidate = 3600; // 1時間（秒単位）
+// On-Demand ISR (microCMS Webhook → /api/revalidate) で即時反映する。
+// 下記の数値は Webhook が万一失敗した場合のフォールバックの最大鮮度。
+export const revalidate = 86400; // 24時間（秒単位）。通常は webhook 経由で即時更新される
 
 export default async function Home() {
   // MicroCMSから次回のイベントを取得


### PR DESCRIPTION
## Summary
- microCMS 編集後の反映が最大1時間待ちだった問題を解決。Webhook 駆動の On-Demand Revalidation で**即時反映**に切り替え。
- ISR 周期は 3600s → 86400s に格下げ（Webhook が万一失敗した場合のフォールバック）。
- 新規エンドポイント `POST /api/revalidate` は HMAC-SHA256 署名検証 + endpoint allowlist + DoS 上限つき。

## なぜ Webhook か（代替案を却下した理由）
| 案 | デメリット | 判定 |
|---|---|---|
| cron 5 分間隔 | API 制限を圧迫、編集者は最大5分待ち、無駄ビルド多数 | ✗ |
| ISR 周期短縮（5分） | 同上 | ✗ |
| Webhook + On-Demand | 即時反映、無駄ビルドゼロ、API 消費最小 | ✓ 採用 |

## セキュリティ対策
- HMAC-SHA256 署名検証（`X-MICROCMS-Signature`）。raw body に対して計算
- timing-safe な hex 比較（`crypto.timingSafeEqual` + 長さ事前検査で非hex silent truncation も弾く）
- DoS 防止：`Content-Length` 64KB cap + body 読込後の再チェック（HMAC 計算より**前**に reject）
- `revalidatePath` は `ENDPOINT_TO_PATHS` 定数 allowlist 経由（攻撃者が任意 path を invalidate 不可）
- `MICROCMS_WEBHOOK_SECRET` 未設定時は 500 で早期遮断
- `runtime = 'nodejs'` 明示（`node:crypto` 必要）

### pre-pr-review 結果
- security-reviewer + codex:review 並列実行
- CRITICAL/HIGH: なし
- MEDIUM: body 上限なし → **本PRで修正済み**（64KB cap 追加）
- LOW: リプレイ防御なし → 受容（microCMS が timestamp 出さないため対策困難、影響はキャッシュ再生成のみ）

## デプロイ後にやること（マージ者向け）
1. Vercel に環境変数 `MICROCMS_WEBHOOK_SECRET` を追加（`openssl rand -hex 32` で生成）
2. microCMS 管理画面 → サービス設定 → API → `events` と `hero` の各 Webhook で
   - URL: `https://<本番ドメイン>/api/revalidate`
   - シークレット: 上と同じ値
3. microCMS で適当に1件更新 → ブラウザ F5 → 即反映を確認

## Test plan
- [ ] `npm run build` 成功
- [ ] `tsc --noEmit` パス済み（このPRの時点で確認済み）
- [ ] Vercel preview で `/api/revalidate` が POST を受け付ける（GET は 405）
- [ ] 偽署名で 401 を返すことを curl で確認
- [ ] 巨大 body (>64KB) で 413 を返すことを確認
- [ ] microCMS で events を更新 → `/event` が即時更新されることを確認
- [ ] microCMS で hero を更新 → `/` が即時更新されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)